### PR TITLE
Implement ModuLearn scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Streamlit
+.streamlit/
+
+# Node
+node_modules/
+
+# Misc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# hello.github
+# ModuLearn
+
+ModuLearn is a demo project for building AI-generated micro-curriculums for underserved schools.
+
+## Structure
+
+- `generator/` – Python module that handles AI-based curriculum generation.
+- `frontend/` – Streamlit interface for teachers to request a learning module.
+- `data/` – Sample data and outputs.
+- `docs/` – Documentation on standards and design notes.
+
+## Running
+
+Install the requirements and launch the Streamlit app:
+
+```bash
+pip install -r requirements.txt
+streamlit run frontend/app.py
+```
+
+The generator uses the OpenAI API. Set the environment variable `OPENAI_API_KEY` with your key before running.
+
+## License
+
+MIT

--- a/data/sample_input.json
+++ b/data/sample_input.json
@@ -1,0 +1,4 @@
+{
+  "topic": "Intro to Coding",
+  "length": 5
+}

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -1,0 +1,9 @@
+# Standards Alignment
+
+ModuLearn aims to align generated lessons with the following standards:
+
+- **NGSS** – Next Generation Science Standards
+- **CSTA** – Computer Science Teachers Association
+- **ISTE** – International Society for Technology in Education
+
+This folder can hold research notes and guidelines used when prompting the AI.

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,18 @@
+import os
+import streamlit as st
+from generator import generate_module, save_module
+
+st.title("ModuLearn - Curriculum Builder")
+
+st.sidebar.header("Module Options")
+topic = st.sidebar.text_input("Topic", "Intro to Coding")
+length = st.sidebar.slider("Length (days)", min_value=1, max_value=10, value=5)
+
+if st.sidebar.button("Generate Module"):
+    with st.spinner("Generating..."):
+        module = generate_module(topic, length)
+        save_module(module, f"../data/{topic.replace(' ', '_')}.json")
+        st.success("Module generated!")
+        st.json(module)
+else:
+    st.write("Enter a topic and click Generate Module to create a curriculum.")

--- a/generator/__init__.py
+++ b/generator/__init__.py
@@ -1,0 +1,3 @@
+from .generate import generate_module, save_module
+
+__all__ = ["generate_module", "save_module"]

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -1,0 +1,37 @@
+"""Simple curriculum module generator."""
+
+import os
+import json
+from typing import Dict
+
+import openai
+
+
+def generate_module(topic: str, length: int = 5) -> Dict:
+    """Generate a micro-curriculum module using OpenAI."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY not set")
+    openai.api_key = api_key
+
+    prompt = f"Create a {length}-day STEM curriculum about {topic}."\
+             " Provide slides, worksheets, and a mini-project." 
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.7,
+    )
+
+    content = response.choices[0].message["content"]
+    return {"topic": topic, "content": content}
+
+
+def save_module(module: Dict, path: str) -> None:
+    with open(path, "w") as f:
+        json.dump(module, f, indent=2)
+
+
+if __name__ == "__main__":
+    module = generate_module("Intro to Coding")
+    save_module(module, "../data/sample_module.json")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai>=0.27
+streamlit>=1.20


### PR DESCRIPTION
## Summary
- replace placeholder README with ModuLearn project info
- ignore Python & Streamlit artifacts
- add sample curriculum generator using OpenAI
- create Streamlit UI for teachers
- document standards alignment
- include example data and requirements file

## Testing
- `python -m py_compile generator/generate.py frontend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684ae46848cc8325a7aa9044ca209753