### PR TITLE
Add Streamlit curriculum generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# hello.github
+# ModuLearn
+
+This repository contains a simple Streamlit app that generates curriculum modules.
+
+## Running
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the Streamlit application:
+   ```bash
+   streamlit run frontend/app.py
+   ```
+
+The generated modules are saved as JSON files in the `data/` folder.

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,19 @@
+import os
+import streamlit as st
+from generator import generate_module, save_module
+
+st.title("ModuLearn - Curriculum Builder")
+
+st.sidebar.header("Module Options")
+topic = st.sidebar.text_input("Topic", "Intro to Coding")
+length = st.sidebar.slider("Length (days)", min_value=1, max_value=10, value=5)
+
+if st.sidebar.button("Generate Module"):
+    with st.spinner("Generating..."):
+        module = generate_module(topic, length)
+        os.makedirs("../data", exist_ok=True)
+        save_module(module, f"../data/{topic.replace(' ', '_')}.json")
+        st.success("Module generated!")
+        st.json(module)
+else:
+    st.write("Enter a topic and click Generate Module to create a curriculum.")

--- a/generator.py
+++ b/generator.py
@@ -1,0 +1,14 @@
+import json
+from typing import Dict
+
+def generate_module(topic: str, length: int) -> Dict:
+    """Create a simple module outline for the given topic."""
+    days = [f"Day {i+1}: Learn about {topic}" for i in range(length)]
+    return {"topic": topic, "length": length, "schedule": days}
+
+
+def save_module(module: Dict, path: str) -> None:
+    """Save the module dictionary to a JSON file."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(module, f, indent=2)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit


### PR DESCRIPTION
## Summary
- implement a simple curriculum generator
- create Streamlit frontend to generate modules
- document running instructions

## Testing
- `python -m py_compile frontend/app.py generator.py`


------
https://chatgpt.com/codex/tasks/task_e_684c2a0ebaec8325866a069236693c20